### PR TITLE
Added error handling for mongoose.connect

### DIFF
--- a/src/loaders/mongooseLoader.js
+++ b/src/loaders/mongooseLoader.js
@@ -4,7 +4,7 @@ const HOST_NAME = 'localhost';
 const DATABASE_NAME = 'Database';
 
 function load() {
-  mongoose.connect('mongodb://' + HOST_NAME + '/' + DATABASE_NAME);
+  mongoose.connect('mongodb://' + HOST_NAME + '/' + DATABASE_NAME).catch(error => console.error(error));
   mongoose.connection.on('connect', () => console.log('MongoDB connected'));
 }
 

--- a/src/loaders/mongooseLoader.js
+++ b/src/loaders/mongooseLoader.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const mongoose = require('mongoose');
 
 function load() {
-  mongoose.connect(process.env.DB_KEY);
+  mongoose.connect(process.env.DB_KEY).catch(error => console.error(error));
   mongoose.connection.on('connect', () => console.log('MongoDB connected'));
 }
 


### PR DESCRIPTION
Without a `.catch` statement, and on a connection error, the API would simply print nothing, rather than provide valid debug information.